### PR TITLE
Using a method for accessing groups of data set

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -15,6 +15,13 @@ only a single group, this will be always the root group `"/"`.
 """
 groupname(ds::AbstractDataset) = "/"
 
+"""
+    CommonDatamodel.groups(ds::AbstractDataset)
+
+All the group names of the data set. For a data set containing
+only a single group, this will be an empty vector of `String`.
+"""
+groups(ds::AbstractDataset) = String[]
 
 """
     CommonDatamodel.unlimited(ds::AbstractDataset)
@@ -74,7 +81,7 @@ function Base.show(io::IO,ds::AbstractDataset)
     end
 
     # groups
-    groupnames = keys(ds.group)
+    groupnames = groups(ds)
 
     if length(groupnames) > 0
         printstyled(io, indent, "Groups\n",color=section_color[])


### PR DESCRIPTION
Currently the `Base.show(io::IO,ds::AbstractDataset)` is directly accessing the field `ds.group`, causing an issue when showing datasets that don't have a `group` field. This PR adds a `groups(ds::AbstractDataset)` method that should return a vector of strings with the group name and an empty string vector if a single group exists. The `show` method has been updated accordingly.