### PR TITLE
`name` for `CFVariable`

### DIFF
--- a/src/cfvariable.jl
+++ b/src/cfvariable.jl
@@ -21,6 +21,8 @@ Return a tuple of integers with the size of the variable `var`.
 """
 Base.size(v::CFVariable) = size(v.var)
 
+name(v::CFVariable) = name(v.var)
+
 attribnames(v::CFVariable) = keys(v.attrib)
 attrib(v::CFVariable,name::AbstractString) = v.attrib[name]
 


### PR DESCRIPTION
the `name` method was not implemented for `CFVariable`.