### PR TITLE
Symbol or string

### DIFF
--- a/src/CommonDataModel.jl
+++ b/src/CommonDataModel.jl
@@ -59,6 +59,8 @@ abstract type AbstractVariable{T,N} <: AbstractArray{T, N}
 end
 
 
+const SymbolOrString = Union{Symbol, AbstractString}
+
 include("dataset.jl")
 include("variable.jl")
 include("cfvariable.jl")

--- a/src/attribute.jl
+++ b/src/attribute.jl
@@ -7,20 +7,20 @@ attribnames(ds::Union{AbstractDataset,AbstractVariable}) = ()
 
 
 """
-    CommonDatamodel.attrib(ds::Union{AbstractDataset,AbstractVariable},attribname::AbstractString)
+    CommonDatamodel.attrib(ds::Union{AbstractDataset,AbstractVariable},attribname::SymbolOrString)
 
 Return the length of the attributes `attribname` in the data set `ds`.
 """
-function attrib(ds::Union{AbstractDataset,AbstractVariable},attribname::AbstractString)
+function attrib(ds::Union{AbstractDataset,AbstractVariable},attribname::SymbolOrString)
     error("no attributes $attribname in $(path(ds))")
 end
 
 """
-    CommonDatamodel.defAttrib(ds::Union{AbstractDataset,AbstractVariable},name::AbstractString,data)
+    CommonDatamodel.defAttrib(ds::Union{AbstractDataset,AbstractVariable},name::SymbolOrString,data)
 
 Create an attribute with the name `attrib` in the data set or variable `ds`.
 """
-function defAttrib(ds::AbstractDataset,name::AbstractString,data)
+function defAttrib(ds::AbstractDataset,name::SymbolOrString,data)
     error("unimplemnted for abstract type")
 end
 

--- a/src/cfvariable.jl
+++ b/src/cfvariable.jl
@@ -26,10 +26,10 @@ dataset(v::CFVariable) = dataset(v.var)
 
 
 attribnames(v::CFVariable) = keys(v.attrib)
-attrib(v::CFVariable,name::AbstractString) = v.attrib[name]
+attrib(v::CFVariable,name::SymbolOrString) = v.attrib[name]
 
 dimnames(v::CFVariable) = dimnames(v.var)
-dim(v::CFVariable,name::AbstractString) = dim(v.var,name)
+dim(v::CFVariable,name::SymbolOrString) = dim(v.var,name)
 
 # necessary for IJulia if showing a variable from a closed file
 Base.show(io::IO,::MIME"text/plain",v::AbstractVariable) = show(io,v)
@@ -38,7 +38,7 @@ Base.display(v::AbstractVariable) = show(stdout,v)
 
 
 """
-    v = cfvariable(ds::NCDataset,varname::AbstractString; <attrib> = <value>)
+    v = cfvariable(ds::NCDataset,varname::SymbolOrString; <attrib> = <value>)
 
 Return the NetCDF variable `varname` in the dataset `ds` as a
 `NCDataset.CFVariable`. The keyword argument `<attrib>` are

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -27,21 +27,21 @@ groupnames(ds::AbstractDataset) = ()
 
 
 """
-    CommonDatamodel.group(ds::AbstractDataset,groupname::AbstractString)
+    CommonDatamodel.group(ds::AbstractDataset,groupname::SymbolOrString)
 
 Return the sub-group data set with the name `groupname`.
 """
-function group(ds::AbstractDataset,groupname::AbstractString)
+function group(ds::AbstractDataset,groupname::SymbolOrString)
     error("no group $groupname in $(path(ds))")
 end
 
 """
-    group = CommonDatamodel.defGroup(ds::AbstractDataset,name::AbstractString)
+    group = CommonDatamodel.defGroup(ds::AbstractDataset,name::SymbolOrString)
 
 Create an empty sub-group with the name `name` in the data set `ds`.
 The `group` is a sub-type of `AbstractDataset`.
 """
-function defGroup(ds::AbstractDataset,name::AbstractString)
+function defGroup(ds::AbstractDataset,name::SymbolOrString)
     error("unimplemented for abstract type")
 end
 

--- a/src/dimension.jl
+++ b/src/dimension.jl
@@ -8,28 +8,28 @@ dimnames(ds::Union{AbstractDataset,AbstractVariable}) = ()
 
 
 """
-    CommonDatamodel.dim(ds::AbstractDataset,dimname::AbstractString)
+    CommonDatamodel.dim(ds::AbstractDataset,dimname::SymbolOrString)
 
 Return the length of the dimension `dimname` in the data set `ds`.
 """
-function dim(v::AbstractVariable,name::AbstractString)
+function dim(v::AbstractVariable,dimname::SymbolOrString)
     if !(dimname in dimnames(v))
         error("$dimname is not among the dimensions of $(name(v))")
     end
     return dim(dataset(v),dimname)
 end
 
-function dim(ds::AbstractDataset,dimname::AbstractString)
+function dim(ds::AbstractDataset,dimname::SymbolOrString)
     error("no dimension $dimname in $(path(ds))")
 end
 
 """
-    CommonDatamodel.defDim(ds::AbstractDataset,name::AbstractString,len)
+    CommonDatamodel.defDim(ds::AbstractDataset,name::SymbolOrString,len)
 
 Create dimension with the name `name` in the data set `ds` with the length `len`.
 `len` can be `Inf` for unlimited dimensions.
 """
-function defDim(ds::AbstractDataset,name::AbstractString,len)
+function defDim(ds::AbstractDataset,name::SymbolOrString,len)
     error("unimplemnted for abstract type")
 end
 

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -22,15 +22,15 @@ Return an iterable of all the variable name.
 varnames(ds::AbstractDataset) = ()
 
 """
-    CommonDataModel.variable(ds::AbstractDataset,variablename::AbstractString)
+    CommonDataModel.variable(ds::AbstractDataset,variablename::SymbolOrString)
 
 Return the variable with the name `variablename` from the data set `ds`.
 """
-function variable(ds::AbstractDataset,variablename::AbstractString)
+function variable(ds::AbstractDataset,variablename::SymbolOrString)
     error("no variable $variablename in $(path(ds)) (abstract method)")
 end
 
-function defVar(ds::AbstractDataset,name::AbstractString,type,dimnames)
+function defVar(ds::AbstractDataset,name::SymbolOrString,type,dimnames)
     error("unimplemented for abstract type")
 end
 


### PR DESCRIPTION
I got the request in the past to allow also Symbols to index the dataset and attributes:

https://github.com/Alexander-Barth/NCDatasets.jl/issues/101
https://github.com/Alexander-Barth/NCDatasets.jl/issues/154

In DataFrames.jl for example this is also possible:

```julia
df = DataFrame(a=1:10,b=2:11)
df[:,"a"]
df[:,:a]
```

It would help me a lot with ambiguities error when we relax the definition in CommonDataSet.jl as done in this PR.
For now, I would need to declare two definition for the override methods (one for `AbstractString` and one for `Symbol`):

https://github.com/Alexander-Barth/NCDatasets.jl/blob/master/src/variable.jl#L83


I tried on GRIBDatasets.jl with this PR, and it did not cause a problem.