### PR TITLE
Default Base.keys(ds) to varnames(ds)

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -175,6 +175,9 @@ function Base.setindex!(ds::AbstractDataset,data::AbstractVariable,varname::Symb
     return defVar(ds, varname, data)
 end
 
+function Base.keys(ds::AbstractDataset) 
+    return varnames(ds)
+end
 
 function Base.haskey(ds::AbstractDataset,varname)
     return Symbol(varname) in Symbol.(keys(ds))

--- a/src/defer.jl
+++ b/src/defer.jl
@@ -81,7 +81,7 @@ end
 close(dds::DeferDataset) = nothing
 groupname(dds::DeferDataset) = dds.groupname
 path(dds::DeferDataset) = dds.r.filename
-Base.keys(dds::DeferDataset) = collect(keys(dds.data[:var]))
+varnames(dds::DeferDataset) = collect(keys(dds.data[:var]))
 
 function Variable(f::Function, dv::DeferVariable{T,N,TDS}) where {T,N,TDS}
     TDS(dv.r.filename,dv.r.mode) do ds

--- a/src/memory_dataset.jl
+++ b/src/memory_dataset.jl
@@ -87,7 +87,6 @@ CDM.name(v::Union{MemoryVariable,MemoryDataset}) = v.name
 CDM.dimnames(v::MemoryVariable) = v.dimnames
 CDM.dataset(v::MemoryVariable) = v.parent_dataset
 
-Base.keys(md::MemoryDataset) = keys(md.variables)
 CDM.variable(md::MemoryDataset,varname::SymbolOrString) = md.variables[String(varname)]
 CDM.dimnames(md::MemoryDataset) = keys(md.dimensions)
 CDM.maskingvalue(md::MemoryDataset) = md.maskingvalue

--- a/src/multifile.jl
+++ b/src/multifile.jl
@@ -168,7 +168,7 @@ name(mfds::MFDataset) = name(mfds.ds[1])
 # to depreciate?
 groupname(mfds::MFDataset) = name(mfds.ds[1])
 
-function Base.keys(mfds::MFDataset)
+function varnames(mfds::MFDataset)
     if mfds.aggdim == ""
         return unique(Iterators.flatten(keys.(mfds.ds)))
     else

--- a/src/subvariable.jl
+++ b/src/subvariable.jl
@@ -170,7 +170,7 @@ function variable(ds::SubDataset,varname::Union{AbstractString, Symbol})
 end
 
 
-Base.keys(ds::SubDataset) = keys(ds.ds)
+varnames(ds::SubDataset) = keys(ds.ds)
 path(ds::SubDataset) = path(ds.ds)
 groupname(ds::SubDataset) = groupname(ds.ds)
 

--- a/test/test_multifile.jl
+++ b/test/test_multifile.jl
@@ -269,6 +269,7 @@ ds = TDS(fnames,aggdim = "", deferopen = false);
 
 ds_all = TDS.(fnames)
 mfds = CDM.MFDataset(ds_all,aggdim = "")
+@test keys(mfds) == CDM.varnames(mfds)
 @test sort(keys(mfds)) == ["ampl", "lat", "lon", "time", "vel"]
 
 # save a merged file

--- a/test/test_subvariable.jl
+++ b/test/test_subvariable.jl
@@ -1,6 +1,6 @@
 
 #import NCDatasets
-using CommonDataModel: subsub, SubDataset, SubVariable, chunking, deflate, path, @select
+using CommonDataModel: subsub, SubDataset, SubVariable, chunking, deflate, path, @select, varnames
 using DataStructures
 using Test
 
@@ -148,6 +148,11 @@ show(io,view(ncvar,:,:));
 indices = (lon = 3:4, lat = 1:3)
 
 sds = SubDataset(ds,indices)
+
+#test keys and varnames
+@test keys(ds) == varnames(ds)
+@test keys(sds) == varnames(sds)
+
 @test size(sds["lon"]) == (2,)
 @test size(sds["lat"]) == (3,)
 @test size(sds["bat"]) == (2,3)


### PR DESCRIPTION
- Add `Base.keys(ds) = varnames(ds) ` keys have a default method.
- Define `varnames` instead of `Base.keys` for Datasets to align better with the interface description.
- Add small tests
See issue for more context. https://github.com/JuliaGeo/CommonDataModel.jl/issues/25