### PR TITLE
Add MetopDatasets.jl to README list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This package contains abstracts type definition for loading and manipulating GRI
 | GRIB    | [`GRIBDatasets`](https://github.com/JuliaGeo/GRIBDatasets.jl)        |            ✔ |             - |
 | geoTIFF | [`TIFFDatasets`](https://github.com/Alexander-Barth/TIFFDatasets.jl) |            ✔ |             - |
 | Zarr    | [`ZarrDatasets`](https://github.com/JuliaGeo/ZarrDatasets.jl)        |            ✔ |             ✔ |
+|         | [`MetopDatasets`](https://github.com/eumetsat/MetopDatasets.jl)        |            ✔ |             - |
 
 
 Features include:


### PR DESCRIPTION
I propose adding [MetopDatasets ](https://github.com/eumetsat/MetopDatasets.jl) to the list of package implementing the `CommonDataModel`.

I did not add the format since it is not a general purpose format.  The format is a custom binary format used for specific products from the Metop satellites.  